### PR TITLE
Quotes around strings containing semicolons

### DIFF
--- a/unicodemath_tests.yaml
+++ b/unicodemath_tests.yaml
@@ -240,7 +240,7 @@ tests:
   mathml: |
     <math display="block"><mrow><mo>+</mo><mrow intent=":fenced"><mo>(</mo><mrow><mrow><msub><mi>𝛼</mi><mi>𝑦</mi></msub><msub><mi>𝛽</mi><mi>𝑧</mi></msub></mrow><mo>−</mo><mrow><msub><mi>𝛼</mi><mi>𝑥</mi></msub><msub><mi>𝛽</mi><mi>𝑦</mi></msub></mrow></mrow><mo>)</mo></mrow><mi>𝑦</mi><mi>𝑧</mi></mrow></math>
 
-- unicodemath: 1+ : 𝒢 × 𝒢 → 𝒢
+- unicodemath: "1+ : 𝒢 × 𝒢 → 𝒢"
   mathml: |
     <math display="block"><mrow><mo>+</mo><mo>:</mo><mi>𝒢</mi><mo>×</mo><mi>𝒢</mi><mo stretchy="true">→</mo><mi>𝒢</mi></mrow></math>
 
@@ -784,11 +784,11 @@ tests:
   mathml: |
     <math display="block"><mrow><menclose notation="updiagonalstrike downdiagonalstrike"><mi>𝑎</mi></menclose><menclose notation="updiagonalstrike downdiagonalstrike"><mrow><mi>𝑎</mi><mo>+</mo><mi>𝑏</mi></mrow></menclose><menclose notation="box"><mrow><mi>𝑎</mi><mo>+</mo><mi>𝑏</mi></mrow></menclose><menclose notation="downdiagonalstrike"><mrow><mi>𝑓</mi><mo>+</mo><mi>𝑔</mi></mrow></menclose><menclose notation="updiagonalstrike"><mrow><mi>𝑢</mi><mo>+</mo><mi>𝑖</mi></mrow></menclose></mrow></math>
 
-- unicodemath: 1\\⌊ : 𝒢_n × 𝒢_m \\to 𝒢_{n - m}
+- unicodemath: "1\\⌊ : 𝒢_n × 𝒢_m \\to 𝒢_{n - m}"
   mathml: |
     <math display="block"><mrow><mo>⌊</mo><mo>:</mo><msub><mi>𝒢</mi><mi>𝑛</mi></msub><mo>×</mo><msub><mi>𝒢</mi><mi>𝑚</mi></msub><mo stretchy="true">→</mo><msub><mi>𝒢</mi><mrow intent=":fenced"><mo>{</mo><mrow><mi>𝑛</mi><mo>−</mo><mi>𝑚</mi></mrow><mo>}</mo></mrow></msub></mrow></math>
 
-- unicodemath: 1\\⌋ : 𝒢_n × 𝒢_m \\to 𝒢_{m - n}
+- unicodemath: "1\\⌋ : 𝒢_n × 𝒢_m \\to 𝒢_{m - n}"
   mathml: |
     <math display="block"><mrow><mo>⌋</mo><mo>:</mo><msub><mi>𝒢</mi><mi>𝑛</mi></msub><mo>×</mo><msub><mi>𝒢</mi><mi>𝑚</mi></msub><mo stretchy="true">→</mo><msub><mi>𝒢</mi><mrow intent=":fenced"><mo>{</mo><mrow><mi>𝑚</mi><mo>−</mo><mi>𝑛</mi></mrow><mo>}</mo></mrow></msub></mrow></math>
 
@@ -1508,7 +1508,7 @@ tests:
   mathml: |
     <math display="block"><mrow><msup><mrow intent=":fenced"><mo>{</mo><mi>𝑎</mi><mo>⌋</mo></mrow><mrow intent=":fenced"><mo>⟨</mo><mfrac><mfrac><mn>1</mn><mrow intent=":fenced"><mo>[</mo><mn>2</mn><mo>)</mo></mrow></mfrac><mn>3</mn></mfrac><mo>]</mo></mrow></msup><mo>.</mo></mrow></math>
 
-- unicodemath: 1{v_i: i \\in {1,2,3,4,5}}
+- unicodemath: "1{v_i: i \\in {1,2,3,4,5}}"
   mathml: |
     <math display="block"><mrow intent=":fenced"><mo>{</mo><mrow><msub><mi>𝑣</mi><mi>𝑖</mi></msub><mo>:</mo><mi>𝑖</mi><mo>∈</mo><mrow intent=":fenced"><mo>{</mo><mrow><mn>1,2</mn><mn>,3</mn><mn>,4</mn><mn>,5</mn></mrow><mo>}</mo></mrow></mrow><mo>}</mo></mrow></math>
 
@@ -1748,7 +1748,7 @@ tests:
   mathml: |
     <math display="block"><mi>𝜌</mi></math>
 
-- unicodemath: 1​^* : 𝒢 → 𝒢
+- unicodemath: "1​^* : 𝒢 → 𝒢"
   mathml: |
     <math display="block"><mrow><msup><mspace width="0" /><mo>∗</mo></msup><mo>:</mo><mi>𝒢</mi><mo stretchy="true">→</mo><mi>𝒢</mi></mrow></math>
 
@@ -1976,7 +1976,7 @@ tests:
   mathml: |
     <math display="block"><mo>∧</mo></math>
 
-- unicodemath: 1∧ : 𝒢_n × 𝒢_m → 𝒢_{n+m}
+- unicodemath: "1∧ : 𝒢_n × 𝒢_m → 𝒢_{n+m}"
   mathml: |
     <math display="block"><mrow><mo>∧</mo><mo>:</mo><msub><mi>𝒢</mi><mi>𝑛</mi></msub><mo>×</mo><msub><mi>𝒢</mi><mi>𝑚</mi></msub><mo stretchy="true">→</mo><msub><mi>𝒢</mi><mrow intent=":fenced"><mo>{</mo><mrow><mi>𝑛</mi><mo>+</mo><mi>𝑚</mi></mrow><mo>}</mo></mrow></msub></mrow></math>
 
@@ -2364,15 +2364,15 @@ tests:
   mathml: |
     <math display="block"><mrow><msub><mrow intent=":fenced"><mo>⟨</mo><mrow><msub><mi>𝛼</mi><mn>1</mn></msub><mo>+</mo><mrow><msub><mi>𝛼</mi><mi>𝑥</mi></msub><mi>𝑥</mi></mrow><mo>+</mo><mrow><msub><mi>𝛼</mi><mi>𝑦</mi></msub><mi>𝑦</mi></mrow><mo>+</mo><mrow><msub><mi>𝛼</mi><mi>𝑧</mi></msub><mi>𝑧</mi></mrow><mo>+</mo><mrow><msub><mi>𝛼</mi><mrow><mi>𝑦</mi><mi>𝑧</mi></mrow></msub><mrow><mi>𝑦</mi><mi>𝑧</mi></mrow></mrow><mo>+</mo><mrow><msub><mi>𝛼</mi><mrow><mi>𝑧</mi><mi>𝑥</mi></mrow></msub><mi>𝑧</mi></mrow><mi>𝑥</mi><mo>+</mo><mrow><msub><mi>𝛼</mi><mrow><mi>𝑥</mi><mi>𝑦</mi></mrow></msub><mi>𝑥</mi></mrow><mi>𝑦</mi><mo>+</mo><mrow><msub><mi>𝛼</mi><mrow><mi>𝑥</mi><mi>𝑦</mi><mi>𝑧</mi></mrow></msub><mi>𝑥</mi></mrow><mi>𝑦</mi><mi>𝑧</mi></mrow><mo>⟩</mo></mrow><mrow><mo>−</mo><mn>5</mn></mrow></msub><mo>=</mo><mn>0</mn></mrow></math>
 
-- unicodemath: 1⟨⟩_+ : 𝒢 → 𝒢_+
+- unicodemath: "1⟨⟩_+ : 𝒢 → 𝒢_+"
   mathml: |
     <math display="block"><mrow><msub><mrow intent=":fenced"><mo>⟨</mo><mspace width="0" /><mo>⟩</mo></mrow><mo>+</mo></msub><mo>:</mo><mi>𝒢</mi><mo stretchy="true">→</mo><msub><mi>𝒢</mi><mo>+</mo></msub></mrow></math>
 
-- unicodemath: 1⟨⟩_- : 𝒢 → 𝒢_-
+- unicodemath: "1⟨⟩_- : 𝒢 → 𝒢_-"
   mathml: |
     <math display="block"><mrow><msub><mrow intent=":fenced"><mo>⟨</mo><mspace width="0" /><mo>⟩</mo></mrow><mo>−</mo></msub><mo>:</mo><mi>𝒢</mi><mo stretchy="true">→</mo><msub><mi>𝒢</mi><mo>−</mo></msub></mrow></math>
 
-- unicodemath: 1⟨⟩_r : 𝒢 → 𝒢_r
+- unicodemath: "1⟨⟩_r : 𝒢 → 𝒢_r"
   mathml: |
     <math display="block"><mrow><msub><mrow intent=":fenced"><mo>⟨</mo><mspace width="0" /><mo>⟩</mo></mrow><mi>𝑟</mi></msub><mo>:</mo><mi>𝒢</mi><mo stretchy="true">→</mo><msub><mi>𝒢</mi><mi>𝑟</mi></msub></mrow></math>
 


### PR DESCRIPTION
This PR wraps double quotes around **unicodemath** key's text containing semicolons.
